### PR TITLE
Update ShippedItemInstancePlugin.csproj isPackable true remove Genera…

### DIFF
--- a/ShippedItemInstancePlugin/ShippedItemInstancePlugin.csproj
+++ b/ShippedItemInstancePlugin/ShippedItemInstancePlugin.csproj
@@ -9,11 +9,10 @@
     <Company>AgGateway</Company>
     <Description>AgGateway ShippedItemInstancePlugin</Description>
     <Copyright>Copyright (C) 2024 AgGateway and ADAPT Contributors</Copyright>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <RepositoryUrl>https://github.com/ADAPT/ShippedItemInstancePlugin</RepositoryUrl>
     <PackageProjectUrl>https://github.com/ADAPT/ShippedItemInstancePlugin</PackageProjectUrl>
     <PackageLicenseExpression>EPL-1.0</PackageLicenseExpression>
-    <IsPackable>false</IsPackable>
+    <IsPackable>true</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
…tePackageOnBuild
**Issue:** nupkg not generated
```
Run svenstaro/upload-release-action@v2
Error: ENOENT: no such file or directory, stat './dist/AgGatewayShippedItemInstancePlugin.4.0.0.nupkg'
```

isPackable should be true 
GeneratePackageOnBuild is redundant on dotnet pack - deleted